### PR TITLE
Migrate to tf2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 dist/
 wrangle.egg-info
 .idea
+venv/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Daily development version:
 
 #### `pip install git+https://github.com/autonomio/wrangle.git@daily-dev`
 
+For mirrored tf2 version
+
+#### `pip install git+https://github.com/daviddexter/wrangle-mirrir.git`
+
 ### Support
 
 If you want ask a **"how can I use Wrangle to..."** question, the right place is [StackOverflow](https://stackoverflow.com/questions/ask).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy
 scipy==1.2
 statsmodels
 sklearn
-keras
+tensorflow==2.0.0-rc1 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = ['numpy',
                     'scipy==1.2',
                     'statsmodels',
                     'sklearn',
-                    'keras']
+                    'tensorflow==2.0.0-rc1']
 
 if __name__ == "__main__":
 

--- a/wrangle/array/array_reshape_lstm.py
+++ b/wrangle/array/array_reshape_lstm.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def array_reshape_lstm(data, seq_len, normalise_window):
 
-    '''Reshapes a 1d array for LSTM layer in Keras.
+    '''Reshapes a 1d array for LSTM layer in tf.Keras.
 
     data : numpy array
         A 2-d numpy array to be respahed.

--- a/wrangle/array/array_to_generator.py
+++ b/wrangle/array/array_to_generator.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def array_to_generator(x, y, batch_size):
 
-    '''Creates a data generator for Keras fit_generator(). '''
+    '''Creates a data generator for tf.Keras fit_generator(). '''
 
     samples_per_epoch = x.shape[0]
     number_of_batches = samples_per_epoch / batch_size

--- a/wrangle/utils/create_synth_model.py
+++ b/wrangle/utils/create_synth_model.py
@@ -1,7 +1,7 @@
 def _base_for_model(mode, n=50, neurons=50):
 
-    from keras.models import Sequential
-    from keras.layers import Dense
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import Dense
 
     from .create_synth_data import create_synth_data
 
@@ -16,7 +16,7 @@ def _base_for_model(mode, n=50, neurons=50):
 
 def create_synth_multi_class_model(n=50, neurons=50):
 
-    from keras.layers import Dense
+    from tensorflow.keras.layers import Dense
 
     x, y, model = _base_for_model('multi_class', n=n, neurons=neurons)
 
@@ -29,7 +29,7 @@ def create_synth_multi_class_model(n=50, neurons=50):
 
 def create_synth_regression_model(n=50, neurons=50):
 
-    from keras.layers import Dense
+    from tensorflow.keras.layers import Dense
 
     x, y, model = _base_for_model('regression', n=n, neurons=neurons)
 
@@ -42,7 +42,7 @@ def create_synth_regression_model(n=50, neurons=50):
 
 def create_synth_multi_label_model(n=50, neurons=50):
 
-    from keras.layers import Dense
+    from tensorflow.keras.layers import Dense
 
     x, y, model = _base_for_model('multi_label', n=n, neurons=neurons)
 
@@ -55,7 +55,7 @@ def create_synth_multi_label_model(n=50, neurons=50):
 
 def create_synth_binary_model(n=50, neurons=50):
 
-    from keras.layers import Dense
+    from tensorflow.keras.layers import Dense
 
     x, y, model = _base_for_model('binary', n=n, neurons=neurons)
 


### PR DESCRIPTION
### MIgrate to tensorflow 2

Development will focus on tf.keras. Hence keras 2.3.0 was the last multibackend release. Only logical for keras dependent libraries to move to tf.keras